### PR TITLE
Debug image upload with store data issues

### DIFF
--- a/src/api_services/uploadApi/index.ts
+++ b/src/api_services/uploadApi/index.ts
@@ -35,21 +35,34 @@ export const uploadImageApi2 = async (data: any) => {
 
 
 
-export const uploadImageApi = async (data: any) => {
+export const uploadImageApi = async (
+  data: {
+    uploadUrl: string;
+    fileUri: string;
+    publicUrl?: string;
+    contentType?: string;
+    headers?: Record<string, string>;
+  }
+) => {
   console.log("datazNew3000", data);
   try {
-    // Fetch the file from the URI and convert to blob
+    // Read local file into a Blob
     const response = await fetch(data.fileUri);
     const blob = await response.blob();
 
-    console.log("blob1111", blob);
-    console.log("response999999", response);
+    const resolvedContentType = data.contentType || blob.type || "application/octet-stream";
 
+    // Merge any server-provided headers (e.g., x-amz-acl) with Content-Type
+    const headers: Record<string, string> = {
+      "Content-Type": resolvedContentType,
+      ...(data.headers || {}),
+    };
 
-    // Upload to S3 using raw binary data (NOT FormData)
-    const res = await axios.put(data.uploadUrl, blob);
+    // Upload to S3 using raw binary data with correct headers
+    await axios.put(data.uploadUrl, blob, { headers });
 
-    return res.data;
+    // Return the eventual public URL so callers can persist/use it
+    return data.publicUrl;
   } catch (error) {
     console.error("Error upload Image Transaction:", error);
     throw error;

--- a/src/api_services/uploadApi/uploadMutations.ts
+++ b/src/api_services/uploadApi/uploadMutations.ts
@@ -1,5 +1,6 @@
 import { handleAxiosError } from "@/src/lib/handleAxiosError";
 import { useMutation } from "@tanstack/react-query";
+import React from "react";
 import { getUploadUrl, uploadImageApi } from ".";
 
 export const useGetUploadUrl = (handleStoreData: (data: any) => void) => {
@@ -17,32 +18,73 @@ export const useGetUploadUrl = (handleStoreData: (data: any) => void) => {
   });
 };
 
+const inferContentTypeFromUri = (uri: string | undefined): string | undefined => {
+  if (!uri) return undefined;
+  const pathname = uri.split("?")[0];
+  const ext = pathname.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "png":
+      return "image/png";
+    case "webp":
+      return "image/webp";
+    case "heic":
+      return "image/heic";
+    case "heif":
+      return "image/heif";
+    default:
+      return undefined;
+  }
+};
+
 export const useImageUpload = (storeData: any) => {
+  const lastFileToUploadRef = React.useRef<{ uri: string; contentType?: string } | null>(null);
+
   const { mutate, data, isPending, isError, reset, status } = useMutation({
     mutationFn: uploadImageApi,
+    onSuccess: () => {
+      // Clear queued file on success so we don't re-upload
+      lastFileToUploadRef.current = null;
+    },
+    onError: () => {
+      // Keep the file queued for potential retry by caller
+      // No-op
+    },
   });
 
   console.log("status777", status);
   console.log("data777", data);
   console.log("isPending0000", isPending);
 
-
-
-  const uploadImage = async (image: any) => {
-    console.log("storeDataNew20004", storeData);
-    // console.log("publicUrlNew300", storeData.uploadUrl);
-    console.log("imageAssetNew6000", image);
-    if (storeData) {
+  const tryUploadIfReady = React.useCallback(() => {
+    if (storeData?.uploadUrl && lastFileToUploadRef.current) {
+      const { uri, contentType } = lastFileToUploadRef.current;
       mutate({
-        uploadUrl: storeData?.uploadUrl,
-        // formData: formData,
-        fileUri: image,
+        uploadUrl: storeData.uploadUrl,
+        fileUri: uri,
+        publicUrl: storeData?.publicUrl,
+        headers: storeData?.headers,
+        contentType: contentType || inferContentTypeFromUri(uri),
       });
     }
+  }, [mutate, storeData]);
+
+  React.useEffect(() => {
+    tryUploadIfReady();
+  }, [tryUploadIfReady]);
+
+  const uploadImage = async (imageUri: string, explicitContentType?: string) => {
+    lastFileToUploadRef.current = {
+      uri: imageUri,
+      contentType: explicitContentType || inferContentTypeFromUri(imageUri),
+    };
+    tryUploadIfReady();
   };
 
   const resetImageData = () => {
-    reset(); // This will reset the data to undefined
+    reset();
   };
 
   return {

--- a/src/components/tabs/home-modal/YourFeelingToday/lastSymptomsModal/ImageUploadedDetails.tsx
+++ b/src/components/tabs/home-modal/YourFeelingToday/lastSymptomsModal/ImageUploadedDetails.tsx
@@ -16,6 +16,26 @@ const ImageUploadedDetails = ({
   const [openDropDown, setOpenDropDown] = useState(false);
   const ref = React.useRef<ICarouselInstance>(null);
 
+  const inferType = (fileName?: string) => {
+    if (!fileName) return undefined;
+    const ext = fileName.split(".").pop()?.toLowerCase();
+    switch (ext) {
+      case "jpg":
+      case "jpeg":
+        return "image/jpeg";
+      case "png":
+        return "image/png";
+      case "webp":
+        return "image/webp";
+      case "heic":
+        return "image/heic";
+      case "heif":
+        return "image/heif";
+      default:
+        return undefined;
+    }
+  };
+
   const handleImagePick = async () => {
     try {
       await ImagePicker.requestCameraPermissionsAsync();
@@ -27,9 +47,10 @@ const ImageUploadedDetails = ({
       });
 
       if (!result.canceled) {
-        imageUploadedSelected(result.assets[0].uri);
+        const picked = result.assets[0];
+        imageUploadedSelected(picked.uri, inferType(picked.fileName));
 
-        setImageSelected(result.assets[0].uri);
+        setImageSelected(picked);
       }
     } catch (error) {
       console.log("error from image upload", error);
@@ -62,7 +83,7 @@ const ImageUploadedDetails = ({
               <View className=" w-80 h-56 p-3">
                 <Image
                   source={{
-                    uri: selectedLastSymptom?.symptomImages[0],
+                    uri: imageSelected?.uri || selectedLastSymptom?.symptomImages[0],
                   }}
                   style={{ width: "100%", height: "100%" }}
                   contentFit="cover"

--- a/src/components/tabs/home-modal/YourFeelingToday/lastSymptomsModal/index.tsx
+++ b/src/components/tabs/home-modal/YourFeelingToday/lastSymptomsModal/index.tsx
@@ -118,6 +118,26 @@ const LastSymptomsModal = ({ onCancel, selectedLastSymptom }: any) => {
 
   const getUploadUrlData = useGetUploadUrl(handleStoreData);
 
+  const inferType = (fileName?: string) => {
+    if (!fileName) return undefined;
+    const ext = fileName.split(".").pop()?.toLowerCase();
+    switch (ext) {
+      case "jpg":
+      case "jpeg":
+        return "image/jpeg";
+      case "png":
+        return "image/png";
+      case "webp":
+        return "image/webp";
+      case "heic":
+        return "image/heic";
+      case "heif":
+        return "image/heif";
+      default:
+        return undefined;
+    }
+  };
+
   //UPLOADING
   const {
     uploadImage: imageUploadedSelected,
@@ -126,6 +146,15 @@ const LastSymptomsModal = ({ onCancel, selectedLastSymptom }: any) => {
     isImageUploadError: ImgIsError,
     resetImageData,
   } = useImageUpload(storeData);
+
+  React.useEffect(() => {
+    if (imageSelected?.fileName) {
+      getUploadUrlData.mutate({
+        fileName: imageSelected.fileName,
+        contentType: inferType(imageSelected.fileName),
+      });
+    }
+  }, [imageSelected, getUploadUrlData]);
 
   const onSubmit = (data: any) => {
     const payload = {

--- a/src/components/tabs/home-modal/YourFeelingToday/symptoms/symptomDescriptions/index.tsx
+++ b/src/components/tabs/home-modal/YourFeelingToday/symptoms/symptomDescriptions/index.tsx
@@ -60,6 +60,8 @@ const SymptomsDescriptions = ({
     if (imageSelected) {
       getUploadUrlData.mutate({
         fileName: imageSelected.fileName,
+        contentType:
+          imageSelected.type || imageSelected.mimeType || inferType(imageSelected.fileName),
       });
     }
   }, [imageSelected]);
@@ -91,6 +93,26 @@ const SymptomsDescriptions = ({
 
   console.log("storeDatacompone:", storeData);
 
+  const inferType = (fileName?: string) => {
+    if (!fileName) return undefined;
+    const ext = fileName.split(".").pop()?.toLowerCase();
+    switch (ext) {
+      case "jpg":
+      case "jpeg":
+        return "image/jpeg";
+      case "png":
+        return "image/png";
+      case "webp":
+        return "image/webp";
+      case "heic":
+        return "image/heic";
+      case "heif":
+        return "image/heif";
+      default:
+        return undefined;
+    }
+  };
+
   const handleImagePick = async () => {
     try {
       await ImagePicker.requestCameraPermissionsAsync();
@@ -102,9 +124,10 @@ const SymptomsDescriptions = ({
       });
 
       if (!result.canceled) {
-        imageUploadedSelected(result.assets[0].uri);
+        const picked = result.assets[0];
+        imageUploadedSelected(picked.uri, inferType(picked.fileName));
 
-        setImageSelected(result.assets[0]);
+        setImageSelected(picked);
       }
     } catch (error) {
       console.log("error from image upload", error);

--- a/src/hooks/useImageUploadWithStore/index.tsx
+++ b/src/hooks/useImageUploadWithStore/index.tsx
@@ -18,7 +18,7 @@ export const useImageUploadWithStore = () => {
   }, []);
 
   // Initialize hooks with current publicUrl
-  const getUploadUrlData = useGetUploadUrl(handleStoreData, publicUrl);
+  const getUploadUrlData = useGetUploadUrl(handleStoreData);
   const {
     uploadImage: imageUploadedSelected,
     imageData: itemImgData,
@@ -28,10 +28,31 @@ export const useImageUploadWithStore = () => {
   } = useImageUpload(storeData);
 
   // Auto-trigger upload URL when image is selected
+  const inferType = (fileName?: string) => {
+    if (!fileName) return undefined;
+    const ext = fileName.split(".").pop()?.toLowerCase();
+    switch (ext) {
+      case "jpg":
+      case "jpeg":
+        return "image/jpeg";
+      case "png":
+        return "image/png";
+      case "webp":
+        return "image/webp";
+      case "heic":
+        return "image/heic";
+      case "heif":
+        return "image/heif";
+      default:
+        return undefined;
+    }
+  };
+
   React.useEffect(() => {
     if (imageSelected) {
       getUploadUrlData.mutate({
         fileName: imageSelected.fileName,
+        contentType: inferType(imageSelected.fileName),
       });
     }
   }, [imageSelected, getUploadUrlData]);
@@ -48,8 +69,9 @@ export const useImageUploadWithStore = () => {
       });
 
       if (!result.canceled) {
-        imageUploadedSelected(result.assets[0].uri);
-        setImageSelected(result.assets[0]);
+        const picked = result.assets[0];
+        imageUploadedSelected(picked.uri, inferType(picked.fileName));
+        setImageSelected(picked);
       }
     } catch (error) {
       console.log("error from image upload", error);


### PR DESCRIPTION
Refactor image upload to S3 using presigned URLs with correct `Content-Type` and headers to fix 403 errors and improve UX by queuing uploads until URLs are ready.

The previous implementation was failing with 403 errors because the S3 PUT request for binary data was missing the `Content-Type` header, which is required by presigned URLs. Additionally, the `useImageUpload` hook was attempting to upload before the presigned URL (`storeData`) was available, leading to race conditions. This PR ensures the `Content-Type` is correctly inferred and sent, queues the upload until the presigned URL is fetched, and allows for immediate display of the selected image.

---
<a href="https://cursor.com/background-agent?bcId=bc-f551da62-7754-4be5-8ac2-04cfb1049bc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f551da62-7754-4be5-8ac2-04cfb1049bc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

